### PR TITLE
Fix fullscreen not working in Safari

### DIFF
--- a/source/code/helper/fullscreen.ts
+++ b/source/code/helper/fullscreen.ts
@@ -15,6 +15,9 @@ interface VendorPrefixedHTMLElement extends HTMLElement {
     webkitRequestFullScreen?: () => Promise<void>;
 }
 
+// The vendor prefixing is based on:
+// https://hacks.mozilla.org/2012/01/using-the-fullscreen-api-in-web-browsers/
+
 export function setFullscreen(
     elem: VendorPrefixedHTMLElement,
     full = true


### PR DESCRIPTION
With Safari 15.0 on macOS Catalina (10.15.7), the fullscreen checkbox added via `addFullscreenCheckbox()` does not work properly. 

This PR resolves this issue by introducing a set of vendor prefixed alternatives to `elem.requestFullscreen()`, `document.exitFullscreen()`, the `fullscreenchange` event and the `document.fullscreenElement` property.

The fullscreen checkbox has been confirmed to still work at least in the following browsers after this change:

- Safari 15.0, macOS Catalina (10.15.7)
- Chrome 95.0.4638.54, macOS Catalina (10.15.7)
- Firefox 93.0, macOS Catalina (10.15.7)
- Microsoft Edge 95.0.1020.30, macOS Catalina (10.15.7)